### PR TITLE
Make user confirmation route accessible when not logged in

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -50,6 +50,7 @@ defmodule Opencov.Router do
     get "/login", AuthController, :login
     post "/login", AuthController, :make_login
     resources "/users", UserController, only: [:new, :create]
+    get "/users/confirm", UserController, :confirm
     get "/profile/password/reset_request", ProfileController, :reset_password_request
     post "/profile/password/reset_request", ProfileController, :send_reset_password
     get "/profile/password/reset", ProfileController, :reset_password
@@ -63,8 +64,6 @@ defmodule Opencov.Router do
     delete "/logout", AuthController, :logout
 
     get "/", ProjectController, :index
-
-    get "/users/confirm", UserController, :confirm
 
     get "/profile", ProfileController, :show
     put "/profile", ProfileController, :update


### PR DESCRIPTION
As I was testing this out, I found that new users could not reach the route to confirm their email address, because they were being redirected to log in (which they could not do, because the account was not confirmed yet). I fixed this by moving the confirmation route into the anonymous scope.