### PR TITLE
Fix a duplicated 'about' on build view

### DIFF
--- a/web/templates/build/show.html.eex
+++ b/web/templates/build/show.html.eex
@@ -14,7 +14,7 @@
 
   <div class="build-changes">
 
-    <h3>Latest change <span class="small">about <%= human_time_ago(@build.inserted_at) %></span></h3>
+    <h3>Latest change <span class="small"><%= human_time_ago(@build.inserted_at) %></span></h3>
     <div class="latest-change">
       <%= render "commit.html", build: @build %>
     </div>


### PR DESCRIPTION
`human_time_ago` already prepends 'about ' to the duration.

Right now it looks like this:

> Latest change about about 33 seconds ago