### PR TITLE
Docker image refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,19 @@
-FROM elixir:1.4
+FROM elixir:1.5-alpine
+
+RUN apk add --update-cache build-base git postgresql-client nodejs yarn
+
+WORKDIR /opencov
 
 ENV MIX_ENV prod
 
-RUN apt-get update -qq && apt-get install -y apt-transport-https
+RUN mix local.hex --force && mix local.rebar --force
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+COPY mix.exs mix.lock package.json yarn.lock ./
 
-RUN apt-get install -y build-essential postgresql-client nodejs yarn
+RUN yarn install && mix deps.get
 
-RUN mix local.hex --force
-RUN mix local.rebar --force
+COPY . .
 
-RUN mkdir /opencov
-WORKDIR /opencov
+RUN mix compile && mix assets.compile
 
-ADD mix.exs /opencov/mix.exs
-ADD mix.lock /opencov/mix.lock
-ADD package.json /opencov/package.json
-ADD yarn.lock /opencov/yarn.lock
-
-RUN yarn install
-RUN mix deps.get
-
-ADD . /opencov
-RUN mix compile
-RUN mix assets.compile
+CMD ["mix", "phx.server"]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ Check [config/local.sample.exs](https://github.com/danhper/opencov/blob/master/c
 
 If you already have a database to use, you can simply start the application using docker:
 
+Setup database, run migrations and seeds
 ```
-$ docker run -v /absolute/path/to/local.exs:/opencov/config/local.exs danhper/opencov mix ecto.setup
-$ docker run -v /absolute/path/to/local.exs:/opencov/config/local.exs danhper/opencov mix phoenix.server
+$ docker run --rm -v /absolute/path/to/local.exs:/opencov/config/local.exs danhper/opencov mix ecto.setup
+```
+
+Execute Phoenix Server
+```
+$ docker run -v /absolute/path/to/local.exs:/opencov/config/local.exs danhper/opencov
 ```
 
 This will start the server on the port you set in `local.exs`.

--- a/config/local.sample.exs
+++ b/config/local.sample.exs
@@ -7,7 +7,7 @@ config :opencov, Opencov.Endpoint,
 
 config :opencov, Opencov.Repo,
   adapter: Ecto.Adapters.Postgres,
-  url: "postgres://postgres@postgres/opencov_prod",
+  url: "postgres://postgres:112233@postgres/opencov_prod",
   pool_size: 20
 
 config :opencov, :email,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./postgresql-data:/var/lib/postgresql/data/pgdata
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: 112233
 
   opencov:
     image: danhper/opencov:latest
@@ -14,6 +15,3 @@ services:
       - "4000:4000"
     volumes:
       - ./config/local.sample.exs:/opencov/config/local.exs
-    command: mix phoenix.server
-    links:
-      - postgres


### PR DESCRIPTION
Refactored the docker build file, to use alpine version of elixir 1.5 image, reducing the size from 1.41GB to 515MB.

Added default docker command to run Phoenix server.

- Changed Dockerfile
- Update docker-compose and local database configurations
- Update README to new docker script